### PR TITLE
changed version comparison mechanism in deploy.py

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -33,7 +33,7 @@ import logging
 import datetime
 import enum
 
-if platform.python_version_tuple()<('3','6','0'):
+if tuple(int(i) for i in platform.python_version_tuple())<(3,6,0):
     print('requires python >= 3.6')
     quit(1)
 


### PR DESCRIPTION
The version comparison used to work by comparing the strings inside the tuple. This mechanism returned False, when it should have returned True for Python >= 3.10.x   This behaviour is fixed by converting the strings to integers.